### PR TITLE
Predestroy prefetch

### DIFF
--- a/lib/prefetcher.js
+++ b/lib/prefetcher.js
@@ -13,8 +13,6 @@ module.exports = class Prefetcher {
     this.linear = linear
     this.missing = 0
 
-    this._destroyed = false
-
     this._ondownloadBound = this._ondownload.bind(this)
     this.core.on('download', this._ondownloadBound)
   }
@@ -27,14 +25,10 @@ module.exports = class Prefetcher {
   }
 
   destroy () {
-    if (this._destroyed === true) return
-
     this.core.off('download', this._ondownloadBound)
     if (this.range) this.range.destroy()
     this.range = null
     this.max = 0
-
-    this._destroyed = true
   }
 
   update (position) {

--- a/lib/prefetcher.js
+++ b/lib/prefetcher.js
@@ -13,6 +13,8 @@ module.exports = class Prefetcher {
     this.linear = linear
     this.missing = 0
 
+    this._destroyed = false
+
     this._ondownloadBound = this._ondownload.bind(this)
     this.core.on('download', this._ondownloadBound)
   }
@@ -25,10 +27,14 @@ module.exports = class Prefetcher {
   }
 
   destroy () {
+    if (this._destroyed === true) return
+
     this.core.off('download', this._ondownloadBound)
     if (this.range) this.range.destroy()
     this.range = null
     this.max = 0
+
+    this._destroyed = true
   }
 
   update (position) {

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -98,6 +98,7 @@ class BlobReadStream extends Readable {
   }
 
   _predestroy () {
+    if (this._prefetch) this._prefetch.destroy()
     this.core.close().then(noop, noop)
   }
 


### PR DESCRIPTION
Note: prefetcher.destroy() can now be called multiple times, but that method is idempotent, so that's fine