### PR TITLE
Update to use hypercore 11 in tests & as dev dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
   },
   "devDependencies": {
     "brittle": "^3.1.0",
-    "hypercore": "^10.18.0",
-    "random-access-memory": "^6.0.0",
+    "hypercore": "^11.0.0",
     "standard": "^17.0.0"
   }
 }


### PR DESCRIPTION
Noticed that the tests were using the older Hypercore 10 style, so refactored to use the newer major version.

Had to skip the `clear with diff option` test because `core.clear()` does not return the correct blocks anymore.